### PR TITLE
make `clients:create` output composable

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,17 @@ To create a client:
 ``` bash
 $ heroku clients:create Amazing https://amazing-client.herokuapp.com/auth/heroku/callback
 
+Created client Amazing
+  ID:     66c0743078a45bda1ace505a
+  Secret: 3a791be75df30f2b87bd0a8aff1528ec2441d546407b71a2
+```
+
+Or use the `-s / --shell` option to pipe output straight to your `.env` file:
+
+``` bash
+$ heroku clients:create -s Amazing https://amazing-client.herokuapp.com/auth/heroku/callback >> .env
+$ cat .env
+...
 HEROKU_KEY=66c0743078a45bda1ace505a
 HEROKU_SECRET=3a791be75df30f2b87bd0a8aff1528ec2441d546407b71a2
 ```

--- a/lib/clients.rb
+++ b/lib/clients.rb
@@ -16,6 +16,8 @@ class Heroku::Command::Clients < Heroku::Command::Base
   #
   # create a new OAuth client
   #
+  # -s, --shell  # output config vars in shell format
+  #
   def create
     name = shift_argument
     url  = shift_argument
@@ -30,9 +32,15 @@ class Heroku::Command::Clients < Heroku::Command::Base
       { :name => name, :redirect_uri => url },
       { :accept => "application/vnd.heroku+json; version=3" })
     client = json_decode(raw)
-    puts
-    puts "HEROKU_KEY=#{client["id"]}"
-    puts "HEROKU_SECRET=#{client["secret"]}"
+
+    if options[:shell]
+      puts
+      puts "HEROKU_KEY=#{client["id"]}"
+      puts "HEROKU_SECRET=#{client["secret"]}"
+    else
+      styled_header("Created client #{name}")
+      styled_hash(client)
+    end
   end
 
   # clients:update [ID]


### PR DESCRIPTION
This follows [Omniauth naming conventions](https://github.com/intridea/omniauth#readme) and lets you do this:

``` sh
heroku clients:create foo callback_url >> .env
```
