### PR TITLE
Add clients:show

### DIFF
--- a/lib/clients.rb
+++ b/lib/clients.rb
@@ -62,7 +62,7 @@ class Heroku::Command::Clients < Heroku::Command::Base
       puts "HEROKU_KEY=#{client["id"]}"
       puts "HEROKU_SECRET=#{client["secret"]}"
     else
-      styled_header("Client #{client['name']}")
+      styled_header("Client #{client["name"]}")
       styled_hash(client)
     end
   end


### PR DESCRIPTION
Adding the ability to show details of a specific client with `heroku clients:show [ID]`. Otherwise, it's not possible to view a client's secret once it's been created, other than via the API.
