### PR TITLE
Update JSON processing calls

### DIFF
--- a/lib/common.rb
+++ b/lib/common.rb
@@ -1,7 +1,7 @@
 module Heroku::OAuth
   module Common
     def encode_json(data)
-      Heroku::OkJson.encode(stringify_keys(data))
+      Heroku::Helpers.json_encode(stringify_keys(data))
     end
 
     def headers
@@ -11,7 +11,7 @@ module Heroku::OAuth
     def request
       yield
     rescue Heroku::API::Errors::RequestFailed, Heroku::API::Errors::ErrorWithResponse => e
-      payload = Heroku::OkJson.decode(e.response.body)
+      payload = Heroku::Helpers.json_decode(e.response.body)
       raise(Heroku::Command::CommandFailed, payload["message"])
     end
 


### PR DESCRIPTION
Looks like the namespace has changed, breaking some commands:

```
$ heroku clients:create oauth-test https://local.heroku.com:5000/auth/heroku/callback

 !    Heroku client internal error.
 !    Search for help at: https://help.heroku.com
 !    Or report a bug at: https://github.com/heroku/heroku/issues/new

    Error:       uninitialized constant Heroku::API::OkJson (NameError)
    Backtrace:   /Users/raul/.heroku/plugins/heroku-oauth/lib/common.rb:4:in `encode_json'
                 /Users/raul/.heroku/plugins/heroku-oauth/lib/clients.rb:43:in `block in create'
                 /Users/raul/.heroku/plugins/heroku-oauth/lib/common.rb:12:in `request'
                 /Users/raul/.heroku/plugins/heroku-oauth/lib/clients.rb:40:in `create'
                 /Users/raul/.heroku/client/lib/heroku/command.rb:218:in `run'
                 /Users/raul/.heroku/client/lib/heroku/cli.rb:28:in `start'
                 /usr/bin/heroku:24:in `<main>'

    Command:     heroku clients:create oauth-test https://local.heroku.com:5000/auth/heroku/callback
    Plugins:     heroku-oauth
                 heroku-pipeline

    Version:     heroku-toolbelt/3.3.0 (x86_64-darwin10.8.0) ruby/1.9.3
```
