### PR TITLE
Add `authorizations:update` for PATCH'ing existing authorizations

### DIFF
--- a/lib/authorizations.rb
+++ b/lib/authorizations.rb
@@ -58,15 +58,18 @@ class Heroku::Command::Authorizations < Heroku::Command::Base
   #
   def update
     id = shift_argument || raise(Heroku::Command::CommandFailed, "Usage: authorizations:update [ID] [options]")
-    params = {
-      client: options[:client_id] ?
-        { id: options[:client_id], secret: options[:client_secret] } :
+    payload = {
+      "client" => options[:client_id] ?
+        {
+          "id"     => options[:client_id],
+          "secret" => options[:client_secret]
+        } :
         nil,
-      description: options[:description]
+      "description" => options[:description]
     }
     token = request do
       api.request(
-        :body    => encode_json(options),
+        :body    => encode_json(payload),
         :expects => 200,
         :headers => headers,
         :method  => :patch,


### PR DESCRIPTION
Add a CLI command for updating an authorization, which will allow a user/direct authorization to be patched with an OAuth client.

See heroku/api#2619 for more details.
