### PR TITLE
Allow .local urls

### DIFF
--- a/lib/clients.rb
+++ b/lib/clients.rb
@@ -160,6 +160,7 @@ class Heroku::Command::Clients < Heroku::Command::Base
     return false if uri.scheme == "https"
     # allow localhost, 10.* and 192.* clients for testing
     return false if uri.host == "localhost"
+    return false if uri.host =~ /\.local\z/
     return false if uri.host =~ /\A(10\.|192\.)/
     true
   end


### PR DESCRIPTION
This is useful for local setup when testing with mobile, or terrible browsers
and OSes.

/cc @idan 
