### PR TITLE
Allow JSON output from clients:create and authorizations:create

### DIFF
--- a/commands/clients/create.js
+++ b/commands/clients/create.js
@@ -15,14 +15,19 @@ function * run (context, heroku) {
       redirect_uri: url
     }
   })
-  var client
-  if (context.flags.shell) {
+  let client
+  if (context.flags.shell || context.flags.json) {
     client = yield request
   } else {
     client = yield cli.action(`Creating ${context.args.name}`, request)
   }
-  cli.log(`HEROKU_OAUTH_ID=${client.id}`)
-  cli.log(`HEROKU_OAUTH_SECRET=${client.secret}`)
+
+  if (context.flags.json) {
+    cli.styledJSON(client)
+  } else {
+    cli.log(`HEROKU_OAUTH_ID=${client.id}`)
+    cli.log(`HEROKU_OAUTH_SECRET=${client.secret}`)
+  }
 }
 
 module.exports = {
@@ -32,7 +37,8 @@ module.exports = {
   needsAuth: true,
   args: [{name: 'name'}, {name: 'redirect_uri'}],
   flags: [
-    {name: 'shell', char: 's', description: 'output in shell format'}
+    {name: 'shell', char: 's', description: 'output in shell format'},
+    {name: 'json', description: 'output in json format'}
   ],
   run: cli.command(co.wrap(run))
 }


### PR DESCRIPTION
Sometimes you need more than just the token, in a parseable form. I'm using it like this:

    heroku authorizations:create \
      --description "Example app dev env: ${HEROKU_APP}" \
      --scope identity \
      --expires-in $((3 * 24 * 60 * 60)) \
      --json |
      jq -r '.id + " " + .access_token.token' |
      read HEROKU_OAUTH_ID HEROKU_OAUTH_SECRET