### PR TITLE
Allow clients:rotate via sudo

### DIFF
--- a/lib/commands/clients/rotate.js
+++ b/lib/commands/clients/rotate.js
@@ -1,0 +1,39 @@
+'use strict'
+
+let cli = require('heroku-cli-util')
+let co = require('co')
+let lib = require('../../clients')
+
+function * run (context, heroku) {
+  let id = context.args.id
+
+  cli.log(`Updating ${cli.color.cyan(id)}`)
+
+  let client = yield heroku.request({
+    method: 'POST',
+    path: `/oauth/clients/${encodeURIComponent(id)}/actions/rotate-credentials`
+  })
+
+  if (context.flags.json) {
+    cli.styledJSON(client)
+  } else if (context.flags.shell) {
+    cli.log(`HEROKU_OAUTH_ID=${client.id}`)
+    cli.log(`HEROKU_OAUTH_SECRET=${client.secret}`)
+  } else {
+    cli.styledHeader(client.name)
+    cli.styledObject(client)
+  }
+}
+
+module.exports = {
+  topic: 'clients',
+  command: 'rotate',
+  description: '(sudo) rotate OAuth client secret',
+  args: [{name: 'id'}],
+  flags: [
+    {name: 'json', description: 'output in json format'},
+    {name: 'shell', char: 's', description: 'output in shell format'}
+  ],
+  needsAuth: true,
+  run: cli.command(co.wrap(run))
+}

--- a/lib/commands/clients/rotate.js
+++ b/lib/commands/clients/rotate.js
@@ -2,7 +2,6 @@
 
 let cli = require('heroku-cli-util')
 let co = require('co')
-let lib = require('../../clients')
 
 function * run (context, heroku) {
   let id = context.args.id

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,6 +17,7 @@ exports.commands = [
   require('./commands/clients/destroy'),
   require('./commands/clients/info'),
   require('./commands/clients/update'),
+  require('./commands/clients/rotate'),
   require('./commands/sessions'),
   require('./commands/sessions/destroy')
 ]

--- a/test/clients/rotate.js
+++ b/test/clients/rotate.js
@@ -1,0 +1,30 @@
+'use strict'
+/* globals describe it beforeEach afterEach */
+
+const cli = require('heroku-cli-util')
+const nock = require('nock')
+const cmd = require('../../lib/commands/clients/rotate')
+const expect = require('unexpected')
+
+describe('clients:rotate', () => {
+  let api
+  beforeEach(() => {
+    cli.mockConsole()
+    api = nock('https://api.heroku.com:443')
+  })
+  afterEach(() => {
+    api.done()
+    nock.cleanAll()
+  })
+
+  it('rotates the client secret', () => {
+    api.post('/oauth/clients/f6e8d969-129f-42d2-854b-c2eca9d5a42e/actions/rotate-credentials')
+      .reply(200, {
+        name: 'awesome',
+        id: 'f6e8d969-129f-42d2-854b-c2eca9d5a42e',
+        redirect_uri: 'https://myapp.com',
+        secret: 'clientsecret'
+      })
+    return cmd.run({args: {id: 'f6e8d969-129f-42d2-854b-c2eca9d5a42e'}, flags: {url: 'https://heroku.com'}})
+  })
+})

--- a/test/clients/rotate.js
+++ b/test/clients/rotate.js
@@ -4,7 +4,6 @@
 const cli = require('heroku-cli-util')
 const nock = require('nock')
 const cmd = require('../../lib/commands/clients/rotate')
-const expect = require('unexpected')
 
 describe('clients:rotate', () => {
   let api


### PR DESCRIPTION
Handy for rotating secrets on pre-existing clients.

PS I think this is right - not done this CLI stuff before ;)